### PR TITLE
Feat: Adicionando um caminho para redirecionar para a tela de classificação

### DIFF
--- a/src/modules/overview/components/genericTable.tsx
+++ b/src/modules/overview/components/genericTable.tsx
@@ -63,7 +63,9 @@ export default function GenericTable({
           </AspectRatio>
         </Td> */}
         <Td>
-          <Link href={`/jogadores`}>{e?.nome ?? "-"}</Link>
+          <Link href={`/visao-geral/classificacao?id=${e.id}`}>
+            {e?.nome ?? "-"}
+          </Link>
         </Td>
         <Td>
           <Link href={`/visao-geral/jogadores?id=${e.id}`}>

--- a/src/pages/visao-geral/classificacao/index.tsx
+++ b/src/pages/visao-geral/classificacao/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../modules/leagues/components/leaguesTable/";


### PR DESCRIPTION
Quando clicar no nome do time, tentei seguir o padrão de roteamento do time, a única duvida foi sobre o destino do link, caso esteja roteando para a pagina errada ajusto rapidamente